### PR TITLE
preparing to add Org in the repo name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,12 +34,14 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://circuitpython.org/libraries>`_
 or individual libraries can be installed using
-`circup <https://github.com/adafruit/circup>`_.Installing from PyPI
+`circup <https://github.com/adafruit/circup>`_.
+
+Installing from PyPI
 =====================
 
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
-PyPI <https://pypi.org/project/adafruit-circuitpython-displayio_annotation/>`_.
+PyPI <https://pypi.org/project/circuitpython-displayio_annotation/>`_.
 To install for current user:
 
 .. code-block:: shell

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Introduction
     :alt: Discord
 
 
-.. image:: https://github.com/circuitpython/CircuitPython_DisplayIO_Annotation/workflows/Build%20CI/badge.svg
-    :target: https://github.com/circuitpython/CircuitPython_DisplayIO_Annotation/actions
+.. image:: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Annotation/workflows/Build%20CI/badge.svg
+    :target: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Annotation/actions
     :alt: Build Status
 
 
@@ -72,7 +72,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/circuitpython/CircuitPython_DisplayIO_Annotation/blob/main/CODE_OF_CONDUCT.md>`_
+<https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Annotation/blob/main/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ Table of Contents
 .. toctree::
     :caption: Other Links
 
-    Download <https://github.com/circuitpython/CircuitPython_DisplayIO_Annotation/releases/latest>
+    Download <https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Annotation/releases/latest>
     CircuitPython Reference Documentation <https://circuitpython.readthedocs.io>
     CircuitPython Support Forum <https://forums.adafruit.com/viewforum.php?f=60>
     Discord Chat <https://adafru.it/discord>

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     # The project's main homepage.
-    url="https://github.com/circuitpython/CircuitPython_DisplayIO_Annotation.git",
+    url="https://github.com/circuitpython/CircuitPython_Org_DisplayIO_Annotation.git",
     # Author details
     author="CircuitPython Organization",
     author_email="",


### PR DESCRIPTION
These changes are needing for renaming the repository to have Org in the name.

The name of the repository should be changed to `CircuitPython_Org_DisplayIO_Annotation` at the same time that this gets merged.