### PR TITLE
Remove max_size parameter

### DIFF
--- a/displayio_annotation.py
+++ b/displayio_annotation.py
@@ -181,7 +181,7 @@ class Annotation(Widget):
         self._line0 = Line(line_x0, line_y0, line_x1, line_y1, color=line_color)
         self._line1 = Line(line_x1, line_y1, line_x2, line_y2, color=line_color)
 
-        super().__init__(max_size=3)
+        super().__init__()
         # Group elements:
         # 0. Line0 - from (x,y) to (x+delta_x, y+delta_y)
         # 1. Line1 - horizontal line for text

--- a/examples/displayio_annotation_simpletest.py
+++ b/examples/displayio_annotation_simpletest.py
@@ -59,7 +59,7 @@ freeform_annotation = Annotation(
     text="Freeform annotation (display.width, height)",
 )
 
-my_group = displayio.Group(max_size=4)
+my_group = displayio.Group()
 my_group.append(my_switch)
 my_group.append(switch_annotation)
 my_group.append(switch_annotation_under)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Tested on a Pynt:
```
Adafruit CircuitPython 6.3.0 on 2021-06-01; Adafruit PyPortal with samd51j20
```